### PR TITLE
Upgrade Swagger to 0.1.36

### DIFF
--- a/NCS.DSS.Sessions.Tests/NCS.DSS.Sessions.Tests.csproj
+++ b/NCS.DSS.Sessions.Tests/NCS.DSS.Sessions.Tests.csproj
@@ -4,6 +4,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="Properties\**" />
+    <EmbeddedResource Remove="Properties\**" />
+    <None Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
@@ -15,8 +20,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NCS.DSS.Sessions\NCS.DSS.Sessions.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/NCS.DSS.Sessions/NCS.DSS.Sessions.csproj
+++ b/NCS.DSS.Sessions/NCS.DSS.Sessions.csproj
@@ -10,12 +10,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="local.settings.json" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.30" />
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.36" />
     <PackageReference Include="DFC.GeoCoding.Standard" Version="1.0.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />


### PR DESCRIPTION
1. Upgraded Swagger Package from 0.1.30 to 0.1.36
2. Removed unnecessary references to files / folders which did not exist in project 